### PR TITLE
Add pre-scan and progress bar

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -76,19 +76,6 @@ func cacheEntryFilename(ctx context, url string) string {
 	return filepath.Join(ctx.cacheDirectoryPath, ctx.repoOwner, ctx.repoName, sanitize.BaseName(newURL))
 }
 
-// clearEntry clears a specified cache entry.
-func clearEntry(ctx context, url string) error {
-	filename := cacheEntryFilename(ctx, url)
-	return os.Remove(filename)
-}
-
-// Clear clears all cache entries for the repository specified in the
-// fetch context.
-func Clear(ctx context) error {
-	filename := filepath.Join(ctx.cacheDirectoryPath, ctx.repoOwner, ctx.repoName)
-	return os.RemoveAll(filename)
-}
-
 // listilePagination generates the pagination to append to the cache file names
 // for stargazer lists.
 func listFilePagination(page int) string {

--- a/cache.go
+++ b/cache.go
@@ -88,3 +88,15 @@ func Clear(ctx context) error {
 	filename := filepath.Join(ctx.cacheDirectoryPath, ctx.repoOwner, ctx.repoName)
 	return os.RemoveAll(filename)
 }
+
+// listilePagination generates the pagination to append to the cache file names
+// for stargazer lists.
+func listFilePagination(page int) string {
+	return fmt.Sprintf("-list-%d", page)
+}
+
+// contribFilePagination generates the pagination to append to the cache file names
+// for user contribution data.
+func contribFilePagination(page, year int) string {
+	return fmt.Sprintf("-%d-%d", page, year)
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacheEntryFilename(t *testing.T) {
+	ctx := context{
+		repoOwner:          "ullaakut",
+		repoName:           "astronomer",
+		githubToken:        "fakeToken",
+		cacheDirectoryPath: "./data",
+	}
+
+	sanitizedFilename := cacheEntryFilename(ctx, "https://fakeapi.com/graphql?access_token=fakeToken-1-2019")
+
+	assert.Equal(t, "data/ullaakut/astronomer/https-fakeapi-com-graphql-1-2019", sanitizedFilename)
+}

--- a/compute.go
+++ b/compute.go
@@ -58,7 +58,7 @@ func computeTrustReport(ctx context, users []user) (*trustReport, error) {
 		for _, percentile := range percentiles {
 			value, err := stats.Percentile(trustData[contributionScoreFactor], percentile)
 			if err != nil {
-				return nil, fmt.Errorf("unable to compute score trust %dth pervcentile: %v", percentile, err)
+				return nil, fmt.Errorf("unable to compute score trust %2.fth percentile: %v", percentile, err)
 			}
 
 			scorePercentiles[percentile] = trustFactor{

--- a/compute_test.go
+++ b/compute_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildReport(t *testing.T) {
+	expectedFactors := map[factorName]trustFactor{
+		privateContributionFactor:  trustFactor{value: 2 * factorReferences[privateContributionFactor], trustPercent: 0.99},
+		issueContributionFactor:    trustFactor{value: 2 * factorReferences[issueContributionFactor], trustPercent: 0.99},
+		commitContributionFactor:   trustFactor{value: 2 * factorReferences[commitContributionFactor], trustPercent: 0.99},
+		repoContributionFactor:     trustFactor{value: 2 * factorReferences[repoContributionFactor], trustPercent: 0.99},
+		prContributionFactor:       trustFactor{value: 2 * factorReferences[prContributionFactor], trustPercent: 0.99},
+		prReviewContributionFactor: trustFactor{value: 2 * factorReferences[prReviewContributionFactor], trustPercent: 0.99},
+		accountAgeFactor:           trustFactor{value: 2 * factorReferences[accountAgeFactor], trustPercent: 0.99},
+		contributionScoreFactor:    trustFactor{value: 2 * factorReferences[contributionScoreFactor], trustPercent: 0.99},
+	}
+
+	trustData := map[factorName][]float64{
+		privateContributionFactor:  []float64{0, 4 * factorReferences[privateContributionFactor], 2 * factorReferences[privateContributionFactor]},
+		issueContributionFactor:    []float64{0, 2 * factorReferences[issueContributionFactor], 4 * factorReferences[issueContributionFactor]},
+		commitContributionFactor:   []float64{0, 2 * factorReferences[commitContributionFactor], 4 * factorReferences[commitContributionFactor]},
+		repoContributionFactor:     []float64{0, 2 * factorReferences[repoContributionFactor], 4 * factorReferences[repoContributionFactor]},
+		prContributionFactor:       []float64{0, 2 * factorReferences[prContributionFactor], 4 * factorReferences[prContributionFactor]},
+		prReviewContributionFactor: []float64{0, 2 * factorReferences[prReviewContributionFactor], 4 * factorReferences[prReviewContributionFactor]},
+		accountAgeFactor:           []float64{0, 2 * factorReferences[accountAgeFactor], 4 * factorReferences[accountAgeFactor]},
+		contributionScoreFactor:    []float64{0, 2 * factorReferences[contributionScoreFactor], 4 * factorReferences[contributionScoreFactor]},
+	}
+
+	percentiles := map[float64]trustFactor{
+		5:  trustFactor{value: percentileReferences[5], trustPercent: 0.75},
+		10: trustFactor{value: percentileReferences[10], trustPercent: 0.75},
+		15: trustFactor{value: percentileReferences[15], trustPercent: 0.75},
+		20: trustFactor{value: percentileReferences[20], trustPercent: 0.75},
+		25: trustFactor{value: percentileReferences[25], trustPercent: 0.75},
+		30: trustFactor{value: percentileReferences[30], trustPercent: 0.75},
+		35: trustFactor{value: percentileReferences[35], trustPercent: 0.75},
+		40: trustFactor{value: percentileReferences[40], trustPercent: 0.75},
+		45: trustFactor{value: percentileReferences[45], trustPercent: 0.75},
+		50: trustFactor{value: percentileReferences[50], trustPercent: 0.75},
+		55: trustFactor{value: percentileReferences[55], trustPercent: 0.75},
+		60: trustFactor{value: percentileReferences[60], trustPercent: 0.75},
+		65: trustFactor{value: percentileReferences[65], trustPercent: 0.75},
+		70: trustFactor{value: percentileReferences[70], trustPercent: 0.75},
+		75: trustFactor{value: percentileReferences[75], trustPercent: 0.75},
+		80: trustFactor{value: percentileReferences[80], trustPercent: 0.75},
+		85: trustFactor{value: percentileReferences[85], trustPercent: 0.75},
+		90: trustFactor{value: percentileReferences[90], trustPercent: 0.75},
+		95: trustFactor{value: percentileReferences[95], trustPercent: 0.75},
+	}
+
+	report, err := buildReport(trustData, percentiles)
+	require.NoError(t, err)
+	require.NotNil(t, report)
+
+	assert.Equal(t, percentiles, report.percentiles)
+	for factor, expectedTrust := range expectedFactors {
+		assert.Equal(t, expectedTrust, report.factors[factor], "unexpected value for factor %q", factor)
+	}
+}

--- a/console_test.go
+++ b/console_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/ullaakut/disgo"
+)
+
+func TestPrintTrustFactor(t *testing.T) {
+	logger := &bytes.Buffer{}
+	disgo.SetTerminalOptions(disgo.WithColors(false), disgo.WithDefaultOutput(logger), disgo.WithErrorOutput(logger))
+
+	printTrustFactor("test_name", trustFactor{
+		value:        42,
+		trustPercent: 0.99,
+	})
+
+	assert.Contains(t, logger.String(), "test_name:                           42                99%")
+}
+
+func TestPrintPercentile(t *testing.T) {
+	logger := &bytes.Buffer{}
+	disgo.SetTerminalOptions(disgo.WithColors(false), disgo.WithDefaultOutput(logger), disgo.WithErrorOutput(logger))
+
+	printPercentile(42, trustFactor{
+		value:        8484,
+		trustPercent: 0.99,
+	})
+
+	assert.Contains(t, logger.String(), "42th percentile:                     8484              99%")
+}
+
+func TestPrintResult(t *testing.T) {
+	logger := &bytes.Buffer{}
+	disgo.SetTerminalOptions(disgo.WithColors(false), disgo.WithDefaultOutput(logger), disgo.WithErrorOutput(logger))
+
+	printResult("test_name", trustFactor{
+		trustPercent: 0.87,
+	})
+
+	assert.Contains(t, logger.String(), "----------------------------------------------------------")
+	assert.Contains(t, logger.String(), "test_name:                                             87%")
+}
+
+func TestPrintHeader(t *testing.T) {
+	logger := &bytes.Buffer{}
+	disgo.SetTerminalOptions(disgo.WithColors(false), disgo.WithDefaultOutput(logger), disgo.WithErrorOutput(logger))
+
+	printHeader()
+
+	assert.Contains(t, logger.String(), "Averages                             Score           Trust")
+	assert.Contains(t, logger.String(), "--------                             -----           -----")
+}

--- a/factors.go
+++ b/factors.go
@@ -13,7 +13,7 @@ const (
 )
 
 // TODO: If we allow users to choose the year until which
-// to scam, references will be needed for each year.
+// to scan, references will be needed for each year.
 var (
 	factors = []factorName{
 		contributionScoreFactor,
@@ -28,6 +28,8 @@ var (
 
 	percentiles = []float64{5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95}
 
+	// References are based on the average values of values typically
+	// found on popular repositories.
 	factorReferences = map[factorName]float64{
 		privateContributionFactor:  600,
 		contributionScoreFactor:    24000,

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,6 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
 	github.com/ullaakut/disgo v0.3.0
+	github.com/vbauerster/mpb/v4 v4.8.4
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
+github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -106,6 +108,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ullaakut/disgo v0.3.0 h1:2zrEyNBfPRgDVDgzM/qLXZ4Yqt3Lxz7ERvZUSmqSY2M=
 github.com/ullaakut/disgo v0.3.0/go.mod h1:UOgLVyqihzJ7yihrHjYZikivT+AHb9NhT3r1OyPCJqg=
+github.com/vbauerster/mpb/v4 v4.8.4 h1:KaZ/bVd3m7p2qy1R487T53rouanep/AWjnaU7fv/c4k=
+github.com/vbauerster/mpb/v4 v4.8.4/go.mod h1:MxQf3eHZgvVuUmfdEO8DId0YhjNqqFQBEwrzZa06BH4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -114,12 +118,15 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5 h1:8dUaAV7K4uHsF56JQWkprecIQKdPHtR9jCHF5nB8uzc=
+golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -134,6 +141,9 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2 h1:T5DasATyLQfmbTpfEXx/IOL9vfjzW6up+ZDkmHvIf2s=
+golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/gql.go
+++ b/gql.go
@@ -26,6 +26,9 @@ const (
 					edges {
 						cursor
 					}
+					nodes {
+						login
+					}
 				}
 			}
 		}"}`

--- a/gql.go
+++ b/gql.go
@@ -7,14 +7,34 @@ import (
 )
 
 const (
-	usersPerRequest        = 20
-	iso8601Format          = "2006-01-02T15:04:05Z"
-	fetchStargazersRequest = `{"query" : "{
+	// Ask for 100 users per query when listing stargazers.
+	listPagination = 100
+	// Ask for 20 users per query when fetching contribution data.
+	contribPagination = 20
+
+	// ISO8601 time format used by the GitHub API.
+	iso8601Format = "2006-01-02T15:04:05Z"
+
+	// Request to list users. Low cost in terms of rate limiting.
+	fetchUsersRequest = `{"query" : "{
 			rateLimit {
 				limit
-				cost
 				remaining
-				resetAt
+			}
+			repository(owner: \"$repoOwner\", name: \"$repoName\") {
+				stargazers(first: $pagination) {
+					edges {
+						cursor
+					}
+				}
+			}
+		}"}`
+
+	// Request to fetch user contributions. Expensive in terms of rate limiting.
+	// Fetching more than 20 users at a time is pretty much a guaranteed timeout.
+	fetchContributionsRequest = `{"query" : "{
+			rateLimit {
+				remaining
 			}
 			repository(owner: \"$repoOwner\", name: \"$repoName\") {
 				stargazers(first: $pagination) {

--- a/gql.go
+++ b/gql.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	// Ask for 100 users per query when listing stargazers.
+	// Request 100 users per query when listing stargazers.
 	listPagination = 100
-	// Ask for 20 users per query when fetching contribution data.
+
+	// Request 20 users per query when fetching contribution data.
 	contribPagination = 20
 
 	// ISO8601 time format used by the GitHub API.
@@ -63,11 +64,6 @@ const (
 			}
 		}"}`
 )
-
-type repositoryStarScan struct {
-	users     []user
-	updatedAt time.Time
-}
 
 type listStargazersResponse struct {
 	response `json:"data"`

--- a/main.go
+++ b/main.go
@@ -53,10 +53,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		disgo.Errorln(style.Failure(style.SymbolCross, "iissing github access token. Please set one in your GITHUB_TOKEN environment variable, with \"repo\" rights."))
+		os.Exit(1)
+	}
+
 	ctx := context{
 		repoOwner:          repoInfo[0],
 		repoName:           repoInfo[1],
-		githubToken:        os.Getenv("GITHUB_TOKEN"),
+		githubToken:        token,
 		cacheDirectoryPath: viper.GetString("cachedir"),
 		details:            viper.GetBool("details"),
 	}

--- a/main.go
+++ b/main.go
@@ -71,14 +71,16 @@ func detectFakeStars(ctx context) error {
 	disgo.SetTerminalOptions(disgo.WithColors(true), disgo.WithDebug(true))
 
 	disgo.Infof("Beginning fetching process for repository %s/%s\n", ctx.repoOwner, ctx.repoName)
-	cursors, err := fetchStargazers(ctx)
+	cursors, totalUsers, err := fetchStargazers(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to query stargazer data: %s", err)
 	}
 
-	if len(cursors) < 300/contribPagination {
+	if totalUsers < 300 {
 		disgo.Infoln(style.Important("This repository appears to have a low amount of stargazers. Trust calculations might not be accurate."))
 	}
+
+	disgo.Infof("Fetching contributions for %d users up to year %d\n", totalUsers, 2013)
 
 	users, err := fetchContributions(ctx, cursors, 2013)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -80,6 +80,8 @@ func detectFakeStars(ctx context) error {
 		disgo.Infoln(style.Important("This repository appears to have a low amount of stargazers. Trust calculations might not be accurate."))
 	}
 
+	// For now, we only fetch contributions until 2013. It will be configurable later on
+	// once the algorithm is more accurate and more data has been fetched.
 	disgo.Infof("Fetching contributions for %d users up to year %d\n", totalUsers, 2013)
 
 	users, err := fetchContributions(ctx, cursors, 2013)
@@ -89,8 +91,8 @@ func detectFakeStars(ctx context) error {
 
 	report, err := computeTrustReport(ctx, users)
 	if err != nil {
-		disgo.Infof("%+v\n", report)
-		return fmt.Errorf("failed to analyze stargazer data: %v", err)
+		disgo.Errorf("Unable to compute trust report %+v\n", report)
+		return fmt.Errorf("unable to compute trust report: %v", err)
 	}
 
 	renderReport(ctx.details, report)

--- a/query.go
+++ b/query.go
@@ -248,12 +248,8 @@ func isBlacklisted(user string) bool {
 func setupProgressBar(pages int) *mpb.Bar {
 	p := mpb.New(mpb.WithWidth(64))
 
-	name := "Fetching user contributions:"
 	bar := p.AddBar(int64(pages*contribPagination),
 		mpb.BarStyle("[=>-]"),
-		mpb.PrependDecorators(
-			decor.Name(name, decor.WC{W: len(name) + 1, C: decor.DidentRight}),
-		),
 		mpb.AppendDecorators(
 			decor.Name("ETA: "),
 			decor.AverageETA(decor.ET_STYLE_GO),

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildRequestBody(t *testing.T) {
+	tests := map[string]struct {
+		baseRequest string
+		repoOwner   string
+		repoName    string
+		pagination  int
+
+		expectedBody string
+	}{
+		"fetch users request": {
+			baseRequest: fetchUsersRequest,
+			repoOwner:   "ullaakut",
+			repoName:    "cameradar",
+			pagination:  42,
+
+			expectedBody: `{"query":"{ rateLimit{ limit remaining } repository(owner:\"ullaakut\",name:\"cameradar\"){ stargazers(first:42){ edges{ cursor } nodes{ login } } } }"}`,
+		},
+		"fetch contributions request": {
+			baseRequest: fetchContributionsRequest,
+			repoOwner:   "ullaakut",
+			repoName:    "camerattack",
+			pagination:  84,
+
+			expectedBody: `{"query":"{ rateLimit{ remaining } repository(owner:\"ullaakut\",name:\"camerattack\"){ stargazers(first:84){ edges{ cursor } nodes{ login createdAt contributionsCollection(from:\"$dateFrom\",to:\"$dateTo\"){ restrictedContributionsCount totalIssueContributions totalCommitContributions totalRepositoryContributions totalPullRequestContributions totalPullRequestReviewContributions contributionCalendar{ totalContributions } } } } } }"}`,
+		},
+	}
+
+	for description, test := range tests {
+		t.Run(description, func(t *testing.T) {
+			ctx := context{
+				repoOwner: test.repoOwner,
+				repoName:  test.repoName,
+			}
+
+			requestBody := buildRequestBody(ctx, test.baseRequest, test.pagination)
+
+			assert.Equal(t, test.expectedBody, requestBody)
+		})
+	}
+}
+
+func TestGetCursors(t *testing.T) {
+	sg := stargazers{
+		Users: []user{{Login: "titi"}, {Login: "toto"}, {Login: "tete"}, {Login: "tata"}, {Login: "tutu"}},
+		Meta:  metaData{{Cursor: "titi"}, {Cursor: "toto"}, {Cursor: "tete"}, {Cursor: "tata"}, {Cursor: "tutu"}},
+	}
+
+	blacklistedStargazers := stargazers{
+		Users: []user{{Login: "jstrachan"}, {Login: "toto"}, {Login: "tete"}, {Login: "tata"}, {Login: "tutu"}},
+		Meta:  metaData{{Cursor: "jstrachan"}, {Cursor: "toto"}, {Cursor: "tete"}, {Cursor: "tata"}, {Cursor: "tutu"}},
+	}
+
+	tests := map[string]struct {
+		stargazers []stargazers
+		totalUsers int
+
+		expectedCursors []string
+	}{
+		"less users than pagination": {
+			stargazers: []stargazers{
+				sg,
+			},
+			totalUsers: 5,
+
+			expectedCursors: nil,
+		},
+		"exactly as many users as pagination": {
+			stargazers: []stargazers{
+				sg, sg, sg, sg,
+			},
+			totalUsers: 20,
+
+			expectedCursors: nil,
+		},
+		"more users than pagination": {
+			stargazers: []stargazers{
+				sg, sg, sg, sg,
+				sg, sg, sg,
+			},
+			totalUsers: 35,
+
+			expectedCursors: []string{"tutu"},
+		},
+		"way more users than pagination": {
+			stargazers: []stargazers{
+				sg, sg, sg, sg, sg, sg, sg, sg,
+				sg, sg, sg, sg, sg, sg, sg, sg,
+				sg, sg, sg, sg, sg, sg, sg, sg,
+				sg, sg, sg, sg, sg, sg, sg, sg,
+			},
+			totalUsers: 160,
+
+			expectedCursors: []string{"tutu", "tutu", "tutu", "tutu", "tutu", "tutu", "tutu"},
+		},
+		"blacklisted stargazers should dcause page skips": {
+			stargazers: []stargazers{
+				sg, sg, sg, sg, sg, sg, blacklistedStargazers, sg,
+				sg, sg, sg, sg, sg, sg, sg, sg,
+				sg, sg, sg, sg, sg, sg, sg, sg,
+				sg, sg, sg, sg, sg, sg, sg, sg,
+			},
+			totalUsers: 160,
+
+			expectedCursors: []string{"tutu", "tutu", "tutu", "tutu", "tutu", "tutu"},
+		},
+	}
+
+	for description, test := range tests {
+		t.Run(description, func(t *testing.T) {
+			cursors := getCursors(test.stargazers, test.totalUsers)
+
+			assert.Equal(t, test.expectedCursors, cursors)
+		})
+	}
+}
+
+func TestUpdateUsers(t *testing.T) {
+	tests := map[string]struct {
+		users    []user
+		response listStargazersResponse
+		year     int
+
+		expectedUsers []user
+	}{
+		"nil users": {
+			users: nil,
+			response: listStargazersResponse{
+				response: response{
+					Repository: repository{
+						Stargazers: stargazers{
+							Users: []user{
+								{Login: "titi", Contributions: contributions{
+									PrivateContributions: 84,
+									ContributionCalendar: contributionCalendar{
+										TotalContributions: 42,
+									},
+								}},
+								{Login: "toto", Contributions: contributions{
+									PrivateContributions: 21,
+									ContributionCalendar: contributionCalendar{
+										TotalContributions: 67,
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			year: 2019,
+
+			expectedUsers: []user{
+				{Login: "titi", Contributions: contributions{
+					PrivateContributions: 84,
+					ContributionCalendar: contributionCalendar{
+						TotalContributions: 42,
+					},
+				}, yearlyContributions: map[int]int{
+					2019: 126,
+				}},
+				{Login: "toto", Contributions: contributions{
+					PrivateContributions: 21,
+					ContributionCalendar: contributionCalendar{
+						TotalContributions: 67,
+					},
+				}, yearlyContributions: map[int]int{
+					2019: 88,
+				}},
+			},
+		},
+		"update already existing users": {
+			users: []user{
+				{Login: "titi", Contributions: contributions{
+					PrivateContributions: 84,
+					ContributionCalendar: contributionCalendar{
+						TotalContributions: 42,
+					},
+				}, yearlyContributions: map[int]int{
+					2019: 126,
+				}},
+				{Login: "toto", Contributions: contributions{
+					PrivateContributions: 21,
+					ContributionCalendar: contributionCalendar{
+						TotalContributions: 67,
+					},
+				}, yearlyContributions: map[int]int{
+					2019: 88,
+				}},
+			},
+			response: listStargazersResponse{
+				response: response{
+					Repository: repository{
+						Stargazers: stargazers{
+							Users: []user{
+								{Login: "titi", Contributions: contributions{
+									PrivateContributions: 84,
+									ContributionCalendar: contributionCalendar{
+										TotalContributions: 42,
+									},
+								}},
+								{Login: "toto", Contributions: contributions{
+									PrivateContributions: 21,
+									ContributionCalendar: contributionCalendar{
+										TotalContributions: 67,
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			year: 2018,
+
+			expectedUsers: []user{
+				{Login: "titi", Contributions: contributions{
+					PrivateContributions: 168,
+					ContributionCalendar: contributionCalendar{
+						TotalContributions: 42,
+					},
+				}, yearlyContributions: map[int]int{
+					2019: 126,
+					2018: 126,
+				}},
+				{Login: "toto", Contributions: contributions{
+					PrivateContributions: 42,
+					ContributionCalendar: contributionCalendar{
+						TotalContributions: 67,
+					},
+				}, yearlyContributions: map[int]int{
+					2019: 88,
+					2018: 88,
+				}},
+			},
+		},
+	}
+
+	for description, test := range tests {
+		t.Run(description, func(t *testing.T) {
+			users := updateUsers(test.users, test.response, test.year)
+
+			assert.Equal(t, test.expectedUsers, users)
+		})
+	}
+}


### PR DESCRIPTION
## Goal of this PR

This PR fixes #11 and #12

It introduces a new pre-fetch mechanism which quickly gets all stargazers of the repository, 100 by 100, without their contributions. This step is fast and allows Astronomer to do a few new things:

* Filter the list of users to be scanned for contributions, removing blacklisted users (see documentation for more info on blacklisted users)
* Predict the amount of users to scan and generate the cursors that can be used by `fetchContributions` to navigate through the users
	* This means that implementing the fast mode will now be trivial, since we will just need to reduce the number or cursors we give to the `fetchContributions` function, and take random ones. (See #10) 
* Adds a progress bar system, with ETA, elapsed time and a live progress % calculation (thanks to the awesome [mpb library](https://github.com/vbauerster/mpb)!)

Additionally, Astronomer now properly notifies users when their GitHub token is missing. It also updates the documentation to add a gif of Astronomer scanning itself.

## Example

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/6976628/60400618-96cd6480-9b76-11e9-9a85-a849f6858f5d.gif)
