### PR TITLE
Add fast mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Trust is computed based on many different factors:
 * The average amount of public opened pull requests
 * The average amount of public code reviews
 * The average weighted contribution score (weighted by making older contributions more trustworthy)
+* Every 5th percentile, from 5 to 95, of the weighted contribution score
 * The average account age, older is more trustworthy
 
 ## How to use it
@@ -65,8 +66,10 @@ The `astronomer` binary will then be available in `$GOPATH/bin/astronomer`.
 ## Arguments and options
 
 * It is required to specify a repository in the form `repositoryOwner/repositoryName`. This argument's position does not matter.
-* **`-d, --debug`**: Show more detailed trust factors, such as percentiles (default: false)
 * **`-c, --cachedir` (string)**: Set the directory in which to store cache data (default: `./data`)
+* **`-f, --fast`**: Enable fast mode in order to scan random stargazers instead of all of them (slightly less accurate) (default: `true`)
+* **`-s, --stars`**: Maxmimum amount of stars to scan (picked randomly), if fast mode is enabled (default: `1000`)
+* **`-d, --debug`**: Show more detailed trust factors, such as percentiles (default: `false`)
 
 ## Upcoming features
 
@@ -97,11 +100,13 @@ Astronomer only attempts to estimate a trust level. The more stargazers there ar
 
 > _Why would fake stars be an issue? The number of stars doesn't really matter._
 
-Repositories with high amounts of stars, especially when they arrive in bursts, are often found in [GitHub trending](https://github.com/trending), they are also emailed to people who subscribed to the [GitHub Explore](https://github.com/explore?since=daily) daily newsletter. This means that an open source project can get actual users to use their software by bringing attention to it using illegitimate bot accounts. Unfortunately, as far as I know, GitHub currently does not attempt to prevent this from happening.
+Repositories with high amounts of stars, especially when they arrive in bursts, are often found in [GitHub trending](https://github.com/trending), they are also emailed to people who subscribed to the [GitHub Explore](https://github.com/explore?since=daily) daily newsletter. This means that an open source project can get actual users to use their software by bringing attention to it using illegitimate bot accounts. Many startups are known for choosing technologies to use based on GitHub stars, since they provide the comforting thought that the project is backed by a strong community. Unfortunately, as far as I know, GitHub currently does not attempt to prevent this from happening.
 
 > _Why is `Astronomer` so slow? It's been scanning a project for hours._
 
-Astronomer needs to make a lot of queries to the GitHub API in order to fetch all of the user data. It typically needs to do one request per page of stargazers per year of contributions, (as of 2019 that's 11 requests per 30 users). The issue is that the GitHub API is rate limited to 5000 requests per hour, so for a scan of 25000 stars for example, about 9000 requests are required, which will result in at least a two hour scan (takes about 6 hours on my machine/network). I plan on contacting GitHub to try to get a token with more flexible rate limiting, since I believe this project is beneficial to their business, but I'm not confident this request will be accepted.
+If you disabled the fast mode, this is normal. It's fetching all contributions from each individual stargazer of this repository. In most cases, running the scan with fast mode enabled (which is the case by default) should never take more than 30mns to scan a repository, unless you have network issues. It will be slightly less accurate, but significantly faster.
+
+With fast mode disabled, Astronomer needs to make a lot of queries to the GitHub API in order to fetch all of the user data. It typically needs to do one request per page of stargazers per year of contributions, (as of 2019 that's 11 requests per 30 users). The issue is that the GitHub API is rate limited to 5000 requests per hour, so for a scan of 25000 stars for example, about 9000 requests are required, which will result in at least a two hour scan (takes about 6 hours on my machine/network). I plan on contacting GitHub to try to get a token with more flexible rate limiting, since I believe this project is beneficial to their business, but I'm not confident this request will be accepted.
 
 > _How can I contribute to this project?_
 

--- a/cache.go
+++ b/cache.go
@@ -78,12 +78,20 @@ func cacheEntryFilename(ctx context, url string) string {
 
 // listilePagination generates the pagination to append to the cache file names
 // for stargazer lists.
-func listFilePagination(page int) string {
-	return fmt.Sprintf("-list-%d", page)
+func listFilePagination(cursor string) string {
+	if cursor == "" {
+		return fmt.Sprintf("-list-firstpage")
+	}
+
+	return fmt.Sprintf("-list-%s", cursor)
 }
 
 // contribFilePagination generates the pagination to append to the cache file names
 // for user contribution data.
-func contribFilePagination(page, year int) string {
-	return fmt.Sprintf("-%d-%d", page, year)
+func contribFilePagination(cursor string, year int) string {
+	if cursor == "" {
+		return fmt.Sprintf("-firstpage-%d", year)
+	}
+
+	return fmt.Sprintf("-%s-%d", cursor, year)
 }

--- a/query_test.go
+++ b/query_test.go
@@ -60,7 +60,8 @@ func TestGetCursors(t *testing.T) {
 
 	tests := map[string]struct {
 		stargazers []stargazers
-		totalUsers int
+		totalUsers uint
+		starLimit  uint
 
 		expectedCursors []string
 	}{
@@ -69,6 +70,7 @@ func TestGetCursors(t *testing.T) {
 				sg,
 			},
 			totalUsers: 5,
+			starLimit:  100,
 
 			expectedCursors: nil,
 		},
@@ -77,6 +79,7 @@ func TestGetCursors(t *testing.T) {
 				sg, sg, sg, sg,
 			},
 			totalUsers: 20,
+			starLimit:  100,
 
 			expectedCursors: nil,
 		},
@@ -86,6 +89,7 @@ func TestGetCursors(t *testing.T) {
 				sg, sg, sg,
 			},
 			totalUsers: 35,
+			starLimit:  100,
 
 			expectedCursors: []string{"tutu"},
 		},
@@ -97,8 +101,21 @@ func TestGetCursors(t *testing.T) {
 				sg, sg, sg, sg, sg, sg, sg, sg,
 			},
 			totalUsers: 160,
+			starLimit:  200,
 
 			expectedCursors: []string{"tutu", "tutu", "tutu", "tutu", "tutu", "tutu", "tutu"},
+		},
+		"star limit should return less cursors": {
+			stargazers: []stargazers{
+				sg, sg, sg, sg, sg, sg, sg, sg,
+				sg, sg, sg, sg, sg, sg, sg, sg,
+				sg, sg, sg, sg, sg, sg, sg, sg,
+				sg, sg, sg, sg, sg, sg, sg, sg,
+			},
+			totalUsers: 160,
+			starLimit:  100,
+
+			expectedCursors: []string{"tutu", "tutu", "tutu", "tutu"},
 		},
 		"blacklisted stargazers should dcause page skips": {
 			stargazers: []stargazers{
@@ -108,6 +125,7 @@ func TestGetCursors(t *testing.T) {
 				sg, sg, sg, sg, sg, sg, sg, sg,
 			},
 			totalUsers: 160,
+			starLimit:  200,
 
 			expectedCursors: []string{"tutu", "tutu", "tutu", "tutu", "tutu", "tutu"},
 		},
@@ -115,7 +133,12 @@ func TestGetCursors(t *testing.T) {
 
 	for description, test := range tests {
 		t.Run(description, func(t *testing.T) {
-			cursors := getCursors(test.stargazers, test.totalUsers)
+			ctx := context{
+				fastMode: true,
+				stars:    test.starLimit,
+			}
+
+			cursors := getCursors(ctx, test.stargazers, test.totalUsers)
 
 			assert.Equal(t, test.expectedCursors, cursors)
 		})


### PR DESCRIPTION
## Goal of this PR

Fixes #10 

This PR addresses Astronomer's biggest issue at the moment: it is slow. That's why this PR adds the fast mode, enabled by default. The fast mode ensures that if a repository contains more than (by default) 1000 stars, only 1000 random stargazers will be scanned among all.

The fast mode can be disabled by adding `--fast=false`. The amount of stars to compute in fast mode can also be changed by using the `-s` or `--stars` option.

This means that with the default value of 1000, scanning a big repository with thousands of stars takes about 25-30 minutes. (was multiple days in the `v0.1.x` and about 10 hours per 30K stars in the `v0.2.0`&`0.3.0`)

## Examples

<img width="832" alt="Screenshot 2019-07-01 at 8 51 10 PM" src="https://user-images.githubusercontent.com/6976628/60459626-fa709400-9c41-11e9-8dde-0a2d0c260d76.png">
