### PR TITLE
Add mode to scan first stargazers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,31 @@ The `astronomer` binary will then be available in `$GOPATH/bin/astronomer`.
 
 * It is required to specify a repository in the form `repositoryOwner/repositoryName`. This argument's position does not matter.
 * **`-c, --cachedir` (string)**: Set the directory in which to store cache data (default: `./data`)
-* **`-f, --fast`**: Enable fast mode in order to scan random stargazers instead of all of them (slightly less accurate) (default: `true`)
 * **`-s, --stars`**: Maxmimum amount of stars to scan (picked randomly), if fast mode is enabled (default: `1000`)
 * **`-d, --debug`**: Show more detailed trust factors, such as percentiles (default: `false`)
+* **`--fast`**: Enable fast mode in order to scan random stargazers instead of all of them (slightly less accurate) (default: `true`)
+* **`--scanFirstStars`**: Scan the first stars of the repository (overrides fast mode). Set amount of stars with --stars options (default: `false`)
+
+## Example use cases
+
+> _Scanning a repository with detailed statistics_
+
+**With the binary**: `astronomer --details ${repoOwner}/${repoName}`
+**With the docker image**: `docker run -e GITHUB_TOKEN="$GITHUB_TOKEN" -v "/tmp:/data" -t ullaakut/astronomer --details ${repoOwner}/${repoName}`
+
+Note that you can also use the `-d` flag instead of `--details`.
+
+> _Run a full scan of a repository with detailed statistics_
+
+**With the binary**: `astronomer --details --fast=false ${repoOwner}/${repoName}`
+**With the docker image**: `docker run -e GITHUB_TOKEN="$GITHUB_TOKEN" -v "/tmp:/data" -t ullaakut/astronomer --details --fast=false ${repoOwner}/${repoName}`
+
+Make sure to mount a directory that is safe from deletion (not `/tmp` like in this example) as the scan might take hours or days, and if it is stopped while fetching data, the cache folder will allow you to recover to your fetching state in a few seconds. If the cache is lost however, you will need to restart the scan.
+
+> _Scanning the first 500 stars of a repository, with detailed statistics_
+
+**With the binary**: `astronomer --scanFirstStars --stars="500" --details ${repoOwner}/${repoName}`
+**With the docker image**: `docker run -e GITHUB_TOKEN="$GITHUB_TOKEN" -v "/tmp:/data" -t ullaakut/astronomer --scanFirstStars --stars="500" --details ${repoOwner}/${repoName}`
 
 ## Upcoming features
 

--- a/main.go
+++ b/main.go
@@ -62,9 +62,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	if viper.GetUint("stars") < uint(contribPagination) {
+	stars := viper.GetUint("stars")
+	if stars < uint(contribPagination) {
 		disgo.Errorln(style.Failure(style.SymbolCross, " unable to compute less stars than the amount fetched per page. Please set stars to at least ", contribPagination))
 		os.Exit(1)
+	}
+
+	if stars%contribPagination != 0 {
+		stars = stars - stars%contribPagination
+		disgo.Errorln(style.Failure("Rounding amount of stars to get to ", stars, " instead of ", viper.GetUint("stars"), " to match pagination"))
 	}
 
 	ctx := context{

--- a/query.go
+++ b/query.go
@@ -39,14 +39,20 @@ type context struct {
 	cacheDirectoryPath string
 
 	// If fastMode is set to true and that the repository
-	// has more than ${fastModeStars} stargazers, pick
-	// ${fastModeStars}/${contribPagination} number of cursors
+	// has more than ${stars} stargazers, pick
+	// ${stars}/${contribPagination} number of cursors
 	// randomly from all cursors.
 	fastMode bool
 
 	// Amount of stars to scan in fastMode. Will be used only if
 	// fastMode is enabled.
 	stars uint
+
+	// When set to true, overrides the fast mode and simply scans the
+	// first ${stars} stargazers on this repository. Useful to detect
+	// botted/bought stars that were used to initially boost a repo's
+	// popularity.
+	scanFirstStars bool
 
 	// If details is set to true, astronomer will print
 	// additional factors such as percentiles.
@@ -241,6 +247,12 @@ func getCursors(ctx context, sg []stargazers, totalUsers uint) []string {
 			iteration++
 			currentPageUsers++
 		}
+	}
+
+	if ctx.scanFirstStars {
+		disgo.Infof("Scanning first %d stars out of %d\n", ctx.stars, totalUsers)
+		amount := int(ctx.stars) / contribPagination
+		return cursors[len(cursors)-amount+1:]
 	}
 
 	if ctx.fastMode && totalUsers > ctx.stars {


### PR DESCRIPTION
## Goal of this PR

Fixes #18 

This PR introduces a new option to scan the first X stargazers of a repository. This is useful when a repository virtually boosted its popularity by botting/buying stargazers at its infancy but stopped once natural growth was able to sustain itself.

It also improves the error handling with the different user inputs for the `--stars` option.

Here is an example of scanning the same repository with global stats and then with the first 2000 stars it got:

<img width="527" alt="Screenshot 2019-07-01 at 7 34 28 PM" src="https://user-images.githubusercontent.com/6976628/60462871-c3eb4700-9c4a-11e9-9a23-8bcd16f5a1ae.png">

<img width="840" alt="Screenshot 2019-07-01 at 9 53 54 PM" src="https://user-images.githubusercontent.com/6976628/60462883-ca79be80-9c4a-11e9-884d-71f67706521c.png">

As you can see, the organic growth was so high that on average values, the initial boost is completely undetectable. This new option makes it possible to detect it.