### PR TITLE
Fix bugs with low amount of stargazers

### DIFF
--- a/pkg/gql/fetch.go
+++ b/pkg/gql/fetch.go
@@ -401,7 +401,7 @@ func getCursors(ctx *context.Context, sg []stargazers, totalUsers uint) []string
 		}
 	}
 
-	if totalUsers <= 200 {
+	if totalUsers <= 219 {
 		disgo.Infof("All %d stargazers will be scanned\n", totalUsers)
 		return cursors
 	}

--- a/pkg/trust/compute.go
+++ b/pkg/trust/compute.go
@@ -71,7 +71,7 @@ func Compute(ctx *context.Context, users []gql.User) (*Report, error) {
 
 	defer disgo.EndStep()
 
-	if uint(len(users)) >= 200 {
+	if uint(len(users)) > 219 {
 		return buildComparativeReport(trustData)
 	}
 
@@ -80,8 +80,7 @@ func Compute(ctx *context.Context, users []gql.User) (*Report, error) {
 
 func buildReport(trustData map[FactorName][]float64) (*Report, error) {
 	report := &Report{
-		Factors:     make(map[FactorName]Factor),
-		Percentiles: make(map[Percentile]Factor),
+		Factors: make(map[FactorName]Factor),
 	}
 
 	for factor, data := range trustData {
@@ -100,6 +99,7 @@ func buildReport(trustData map[FactorName][]float64) (*Report, error) {
 	// Only compute percentiles if  there are enough stargazers to be
 	// able to compute every fifth percentile.
 	if len(trustData[ContributionScoreFactor]) > 20 {
+		report.Percentiles = make(map[Percentile]Factor)
 		for _, percentile := range percentiles {
 			// Error is ignored on purpose.
 			pctl, _ := strconv.ParseFloat(string(percentile), 64)


### PR DESCRIPTION
## Goal of this PR

This PR fixes to bugs:

* Comparative reports are no longer used before 220 users, since with between 201 and 219 users the second report would have zero values for the percentiles which would set the trust values to zero after comparison.
* For repositories with less than 20 stars, percentiles were shown despite not being computable. This is now fixed by keeping the percentile map nil unless we generate the percentiles.

Fixes #35 and #36 