### PR TITLE
Improve the docker command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ In order to use Astronomer, you'll need a GitHub token with `repo` read rights. 
 
 Run the astronomer docker image like such:
 
-~~~bash
+```bash
 docker run --rm -t -e GITHUB_TOKEN=$TOKEN -v "/path/to/cache:/data" ullaakut/astronomer repositoryOwner/repositoryName
-~~~
+```
 
 * The `-t` flag allows you to get a colored output. You can remove it from the command line if you don't care about this.
 * The `-e GITHUB_TOKEN=<your_token>` option is mandatory. The GitHub API won't authorize any requests without it.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ In order to use Astronomer, you'll need a GitHub token with `repo` read rights. 
 
 ### Docker image
 
-Run `docker pull ullaakut/astronomer`.
+Run the astronomer docker image like such:
 
-Then, use the astronomer docker image like such: `docker run -t -e GITHUB_TOKEN=$GITHUB_TOKEN -v "/path/to/your/cache/folder:/data/" ullaakut/astronomer repositoryOwner/repositoryName`
+~~~bash
+docker run --rm -t -e GITHUB_TOKEN=$TOKEN -v "/path/to/cache:/data" ullaakut/astronomer repositoryOwner/repositoryName
+~~~
 
 * The `-t` flag allows you to get a colored output. You can remove it from the command line if you don't care about this.
 * The `-e GITHUB_TOKEN=<your_token>` option is mandatory. The GitHub API won't authorize any requests without it.


### PR DESCRIPTION
* No need to run the pull command first, as the run command will take care of this -> decrease number of commands to run by 50% :p 
* Use `--rm` flag to remove the container after use
* Make the command slightly shorter
* Use bash syntax coloration