### PR TITLE
Document homebrew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ curl -o $GOPATH/bin/astronomer -sSLO https://github.com/Ullaakut/astronomer/rele
 curl -o $GOPATH/bin/astronomer -sSLO https://github.com/Ullaakut/astronomer/releases/download/v1.1.2/astronomer-darwin-amd64
 ```
 
+**or**
+
+```bash
+brew tap dkanejs/homebrew-astronomer && brew install astronomer
+```
+
 #### Windows
 
 Download [this file](https://github.com/Ullaakut/astronomer/releases/download/v1.1.2/astronomer-windows-386.exe), rename it to `astronomer` and add it to your path.


### PR DESCRIPTION
## Goal of this PR

Fixes #46 by documenting the use of the homebrew tap.

## How to test it

* Run `brew tap dkanejs/homebrew-astronomer && brew install astronomer`
* Run astronomer on a small repository and ensure that it works and the report is properly signed

## Expected

```go
$> brew install astronomer

==> Installing astronomer from dkanejs/astronomer
==> Downloading https://github.com/Ullaakut/astronomer/releases/download/v1.1.2/astronomer-darwin-amd64
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/193044927/30c4f080-a5fe-11e9-9386
######################################################################## 100.0%
🍺  /usr/local/Cellar/astronomer/1.1.2: 3 files, 9.5MB, built in 8 seconds
```