### PR TITLE
Fix infinite loading & percentile calculation on small samples

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func detectFakeStars(ctx *context.Context) error {
 		disgo.Infoln(style.Important("This repository appears to have a low amount of stargazers. Trust calculations might not be accurate."))
 	}
 
-	// For now, we only fetch contributions until 2013. It will be configurable later on
+	// For now, we only fetch contributions since 2013. It will be configurable later on
 	// once the algorithm is more accurate and more data has been fetched.
 	if !ctx.ScanAll && totalUsers > ctx.Stars {
 		disgo.Infof("Fetching contributions for %d users up to year %d\n", ctx.Stars, 2013)

--- a/pkg/gql/fetch.go
+++ b/pkg/gql/fetch.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff/v3"
 	"github.com/Ullaakut/astronomer/pkg/context"
 	"github.com/Ullaakut/disgo"
 	"github.com/Ullaakut/disgo/style"
+	"github.com/cenkalti/backoff/v3"
 	"github.com/vbauerster/mpb/v4"
 	"github.com/vbauerster/mpb/v4/decor"
 )
@@ -190,7 +190,7 @@ func FetchContributions(ctx *context.Context, cursors []string, untilYear int) (
 	requestBody := buildRequestBody(ctx, fetchContributionsRequest, contribPagination)
 	client := &http.Client{}
 
-	progress, bar := setupProgressBar(len(cursors) + 1)
+	progress, bar := setupProgressBar(len(cursors))
 	defer progress.Wait()
 
 	// If we are scanning only a portion of stargazers, the
@@ -209,7 +209,6 @@ func FetchContributions(ctx *context.Context, cursors []string, untilYear int) (
 	// Iterate on pages of user contributions, following the cursors generated
 	// in fetchStargazers.
 	for page := 1; page <= totalPages; page++ {
-
 		currentCursor := getCursor(cursors, page, isReverseOrder)
 
 		// If this isn't the first page, inject the cursor value.
@@ -332,6 +331,8 @@ func FetchContributions(ctx *context.Context, cursors []string, untilYear int) (
 			bar.IncrBy(contribPagination / (currentYear - untilYear))
 		}
 	}
+
+	bar.Abort(true)
 
 	return users, nil
 }

--- a/pkg/trust/compute.go
+++ b/pkg/trust/compute.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/montanaflynn/stats"
 	"github.com/Ullaakut/astronomer/pkg/context"
 	"github.com/Ullaakut/astronomer/pkg/gql"
 	"github.com/Ullaakut/disgo"
 	"github.com/Ullaakut/disgo/style"
+	"github.com/montanaflynn/stats"
 )
 
 // Factor represents one of the trust factors used to compte
@@ -181,6 +181,12 @@ func buildComparativeReport(trustData map[FactorName][]float64) (*Report, error)
 	}
 
 	for _, percentile := range percentiles {
+		// Skip percentiles if the random sample is too small to have percentiles.
+		if currentStarsReport.Percentiles[percentile].TrustPercent == 0 {
+			report.Percentiles = nil
+			break
+		}
+
 		if firstStarsReport.Percentiles[percentile].TrustPercent <= currentStarsReport.Percentiles[percentile].TrustPercent {
 			report.Percentiles[percentile] = firstStarsReport.Percentiles[percentile]
 		} else {
@@ -196,6 +202,10 @@ func buildComparativeReport(trustData map[FactorName][]float64) (*Report, error)
 	}
 
 	for _, percentile := range percentiles {
+		// Skip percentiles if the random sample is too small to have percentiles.
+		if report.Percentiles[percentile].TrustPercent == 0 {
+			break
+		}
 		allTrust = append(allTrust, report.Percentiles[percentile].TrustPercent)
 	}
 


### PR DESCRIPTION
## Goal of this PR

Fixes #89 and a new bug where the loading bar could get stuck waiting for increments and end up hanging forever.

This PR ensures that if the current users sample is small enough not to be eligible for percentiles, those are not taken into account for computing the final report.